### PR TITLE
Dev ticket15 add warehouse_name instead of warehouse_id 

### DIFF
--- a/controllers/inventory-controller.js
+++ b/controllers/inventory-controller.js
@@ -3,7 +3,24 @@ const knex = require("knex")(require("../knexfile"));
 const index = async (_req, res) => {
   try {
     const data = await knex("inventories");
-    res.status(200).json(data);
+    const dataWarehouse = await knex("warehouses");
+
+    const inventoryData = data.map((item) => {
+      const container = {};
+      container.id = item.id;
+      container.warehouse_name = dataWarehouse.find(
+        (w) => w.id === item.warehouse_id
+      ).warehouse_name;
+      container.item_name = item.item_name;
+      container.description = item.description;
+      container.category = item.category;
+      container.status = item.status;
+      container.quantity = item.quantity;
+
+      return container;
+    });
+
+    res.status(200).json(inventoryData);
   } catch (error) {
     res.status(400).send(`Error retrieving inventories: ${error}`);
   }

--- a/controllers/inventory-controller.js
+++ b/controllers/inventory-controller.js
@@ -6,18 +6,29 @@ const index = async (_req, res) => {
     const dataWarehouse = await knex("warehouses");
 
     const inventoryData = data.map((item) => {
-      const container = {};
-      container.id = item.id;
-      container.warehouse_name = dataWarehouse.find(
-        (w) => w.id === item.warehouse_id
-      ).warehouse_name;
-      container.item_name = item.item_name;
-      container.description = item.description;
-      container.category = item.category;
-      container.status = item.status;
-      container.quantity = item.quantity;
+      const {
+        id,
+        warehouse_id,
+        item_name,
+        description,
+        category,
+        status,
+        quantity,
+      } = item;
 
-      return container;
+      const { warehouse_name } = dataWarehouse.find(
+        (w) => w.id === warehouse_id
+      );
+
+      return {
+        id,
+        warehouse_name,
+        item_name,
+        description,
+        category,
+        status,
+        quantity,
+      };
     });
 
     res.status(200).json(inventoryData);


### PR DESCRIPTION
Create an API on the back-end using Express and Express router to provide the front-end with a list of all Inventory items from all Warehouses. 

Note: The warehouse name for each inventory item must also be included in the response.

Data should be returned from your database using knex.

GET /api/inventories

Response returns 200 if successful

Response body example:



[
    {
      "id": 1,
      "warehouse_name": "Manhattan",
      "item_name": "Television",
      "description": "This 50\", 4K LED TV provides a crystal-clear picture and vivid colors.",
      "category": "Electronics",
      "status": "In Stock",
      "quantity": 500
    },
    {
      "id": 2,
      "warehouse_name": "Manhattan",
      "item_name": "Gym Bag",
      "description": "Made out of military-grade synthetic materials, this gym bag is highly durable, water resistant, and easy to clean.",
      "category": "Gear",
      "status": "Out of Stock",
      "quantity": 0
  },