### PR TITLE
Raname warehouses inventories

### DIFF
--- a/controllers/inventory-controller.js
+++ b/controllers/inventory-controller.js
@@ -1,6 +1,6 @@
 const knex = require("knex")(require("../knexfile"));
 
-const index = async (_req, res) => {
+const getAllInventories = async (_req, res) => {
   try {
     const data = await knex("inventories");
     const dataWarehouse = await knex("warehouses");
@@ -38,5 +38,5 @@ const index = async (_req, res) => {
 };
 
 module.exports = {
-  index,
+  getAllInventories,
 };

--- a/controllers/warehouse-controller.js
+++ b/controllers/warehouse-controller.js
@@ -1,6 +1,6 @@
 const knex = require("knex")(require("../knexfile"));
 
-const index = async (_req, res) => {
+const getAllWarehouses = async (_req, res) => {
   try {
     const data = await knex("warehouses");
     res.status(200).json(data);
@@ -10,7 +10,7 @@ const index = async (_req, res) => {
 };
 
 //this is to find a single warehouse
-const findWarehouse = async (req, res) => {
+const getWarehouseById = async (req, res) => {
   try {
     const warehousesFound = await knex("warehouses").where({
       id: req.params.id,
@@ -30,6 +30,6 @@ const findWarehouse = async (req, res) => {
 };
 
 module.exports = {
-  index,
-  findWarehouse,
+  getAllWarehouses,
+  getWarehouseById,
 };

--- a/routes/inventory.js
+++ b/routes/inventory.js
@@ -2,6 +2,6 @@ const router = require("express").Router();
 const inventoryController = require("../controllers/inventory-controller");
 
 //routes handlers
-router.route("/").get(inventoryController.index);
+router.route("/").get(inventoryController.getAllInventories);
 
 module.exports = router;

--- a/routes/warehouses.js
+++ b/routes/warehouses.js
@@ -2,8 +2,8 @@ const router = require("express").Router();
 const warehouseController = require("../controllers/warehouse-controller");
 
 //routes handlers
-router.route("/").get(warehouseController.index);
+router.route("/").get(warehouseController.getAllWarehouses);
 
-router.route("/:id").get(warehouseController.findWarehouse);
+router.route("/:id").get(warehouseController.getWarehouseById);
 
 module.exports = router;


### PR DESCRIPTION
Rename functions to getAllWareHouses and getAllInventories instead of index, and getWarehouseById instead of findWarehouse