### PR TITLE
change callback function name for the /:id route

### DIFF
--- a/routes/inventory.js
+++ b/routes/inventory.js
@@ -4,6 +4,6 @@ const inventoryController = require("../controllers/inventory-controller");
 //routes handlers
 router.route("/").get(inventoryController.getAllInventories);
 
-router.route("/:id").get(inventoryController.findItem);
+router.route("/:id").get(inventoryController.getItemById);
 
 module.exports = router;


### PR DESCRIPTION
The router file(inventory.js) had the incorrect name for the callback function. This is updated now. 